### PR TITLE
Changed shebang to correctly choose Python interpreter

### DIFF
--- a/fnord.py
+++ b/fnord.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 #
 # Fnord
 # Extracting code from scrambled code that could be used in signature based detection


### PR DESCRIPTION
Changed shebang so the correct python3 interpreter is chosen based off of the user's environment.